### PR TITLE
Integrate Google Analytics

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -73,6 +73,8 @@ const siteConfig = {
   },
   */
 
+  gaTrackingId: process.env.GA_TACKING_ID || '',
+
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
   copyright: `Copyright © ${new Date().getFullYear()} Gnosis LTD`,
 


### PR DESCRIPTION
Add `gaTrackingId` to siteConfig.js as a new deployment environment `GA_TACKING_ID`.