### PR TITLE
Minor fixes

### DIFF
--- a/docs/devguide02.md
+++ b/docs/devguide02.md
@@ -10,7 +10,7 @@ oracle in a particular manner. The following function may be used to
 prepare a condition:
 
 
-<span style="color:#009cb4">*function* **prepareCondition** *(address oracle, bytes32 questionId, uint outcomeSlotCount)external*</span>
+<span style="color:#009cb4">*function* **prepareCondition** *(address oracle, bytes32 questionId, uint outcomeSlotCount) external*</span>
 
 This function prepares a condition by initializing a payout vector associated with the condition.
 
@@ -54,7 +54,7 @@ To determine if, given a condition’s ID, a condition has been prepared,
 or to find out a condition’s outcome slot count, use the following
 accessor:
 
-<span style="color:#009cb4">*function* **getOutcomeSlotCount** *(bytes32 conditionId)externalviewreturns(uint)*</span>
+<span style="color:#009cb4">*function* **getOutcomeSlotCount** *(bytes32 conditionId) external view returns (uint)*</span>
 Gets the outcome slot count of a condition.
 
 Parameters:	**conditionId** – ID of the condition.
@@ -113,7 +113,7 @@ web3.utils.soliditySha3({
 A helper function for determining the condition ID also exists on both
 the contract and the <span style="color:#001428">`CTHelpers` </span>   library:
 
-<span style="color:#009cb4">*function* **getConditionId** *(address oracle, bytes32 questionId,uintoutcomeSlotCount)externalpurereturns(bytes32)*</span>
+<span style="color:#009cb4">*function* **getConditionId** *(address oracle, bytes32 questionId, uint outcomeSlotCount) external pure returns (bytes32)*</span>
 
 Constructs a condition ID from an oracle, a question ID, and the outcome slot count for the question.
 

--- a/docs/devguide03.md
+++ b/docs/devguide03.md
@@ -187,7 +187,7 @@ birthday attack](https://link.springer.com/chapter/10.1007/3-540-45708-9_19).**<
 Similar to with conditions, the contract and the `CTHelpers` library
 also provide helper functions for calculating outcome collection IDs:
 
-<span style="color:#009cb4">*function* **getCollectionId** *(bytes32 parentCollectionId, bytes32 conditionId, uint indexSet)externalviewreturns(bytes32)*</span>
+<span style="color:#009cb4">*function* **getCollectionId** *(bytes32 parentCollectionId, bytes32 conditionId, uint indexSet) external view returns (bytes32)*</span>
 	
 Constructs an outcome collection ID from a parent collection and an outcome collection.
 

--- a/docs/devguide04.md
+++ b/docs/devguide04.md
@@ -48,7 +48,7 @@ and <span style="color:#DB3A3D">`$:(A|B)&(LO)`</span> has an ID of
 
 Helper functions for calculating positions also exist:
 
-<span style="color:#009cb4">*function* **getPositionId** *(IERC20 collateralToken, bytes32 collectionId)externalpurereturns (uint)*</span>
+<span style="color:#009cb4">*function* **getPositionId** *(IERC20 collateralToken, bytes32 collectionId) external pure returns (uint)*</span>
 
 Constructs a position ID from a collateral token and an outcome collection. These IDs are used as the ERC-1155 ID for this contract.
 

--- a/docs/devguide05.md
+++ b/docs/devguide05.md
@@ -16,7 +16,7 @@ This function splits a position. If splitting from the collateral, this contract
 - **collateralToken** – The address of the positions’ backing collateral token.
 - **parentCollectionId** – The ID of the outcome collections common to the position being split and the split target positions. May be null, in which only the collateral is shared.
 - **conditionId** – The ID of the condition to split on.
-- **partition** – An array of disjoint index sets representing a nontrivial partition of the outcome slots of the given condition. E.g. A|B and C but not A|B and B|C (is not disjoint). Each element’s a number which, together with the condition, represents the outcome collection. E.g. 0b110 is A|B, 0b010 is B, etc.
+- **partition** – An array of disjoint index sets representing a nontrivial partition of the outcome slots of the given condition. E.g. A|B and C but not A|B and B|C (is not disjoint). Each element’s a number which, together with the condition, represents the outcome collection. E.g. 0b011 is A|B, 0b010 is B, etc.
 -**amount** – The amount of collateral or stake to split.
 
 

--- a/docs/devguide05.md
+++ b/docs/devguide05.md
@@ -8,7 +8,7 @@ Once conditions have been prepared, stake in positions contingent on these condi
 function:
 
 
-<span style="color:#009cb4">*function* **splitPosition** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldatapartition, uint amount)external*</span>
+<span style="color:#009cb4">*function* **splitPosition** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldata partition, uint amount) external*</span>
 
 This function splits a position. If splitting from the collateral, this contract will attempt to transfer amount collateral from the message sender to itself. Otherwise, this contract will burn amount stake held by the message sender in the position being split worth of EIP 1155 tokens. Regardless, if successful, amount stake will be minted in the split target positions. If any of the transfers, mints, or burns fail, the transaction will revert. The transaction will also revert if the given partition is trivial, invalid, or refers to more slots than the condition is prepared with.
 
@@ -197,10 +197,10 @@ collateral to the message sender:
 To merge positions, use the following function:
 
 
-<span style="color:#009cb4">*function* **mergePosition** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldata partition, uint amount)external*</span>
+<span style="color:#009cb4">*function* **mergePosition** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldata partition, uint amount) external*</span>
 
 If successful, the function will emit this event:
 
-<span style="color:#009cb4">*event* **PositionsMerge** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldata partition, uint amount)external*</span>
+<span style="color:#009cb4">*event* **PositionsMerge** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldata partition, uint amount) external*</span>
 
 This generalizes <span style="color:#DB3A3D">`sellAllOutcomes`</span> from Gnosis’ first prediction market contracts like <span style="color:#DB3A3D">`splitPosition`</span> generalizes <span style="color:#DB3A3D">`buyAllOutcomes`</span>.

--- a/docs/devguide06.md
+++ b/docs/devguide06.md
@@ -10,7 +10,7 @@ addition to a holder address, each token is indexed by an ID in this
 standard. In particular, position IDs are used to index conditional
 tokens. This is reflected in the balance querying function:
 
-<span style="color:#009cb4">*function* **balanceOf** *(address owner, uint256 positionId)external view returns (uint256)*</span>
+<span style="color:#009cb4">*function* **balanceOf** *(address owner, uint256 positionId) external view returns (uint256)*</span>
 
 To transfer conditional tokens, the following functions may be used, as
 per ERC1155:
@@ -32,7 +32,7 @@ information.
 Approving an operator account to transfer conditional tokens on your
 behalf may also be done via:
 
-<span style="color:#009cb4">*function* **setApprovalForAll** *(address operator, bool approved)external*</span>
+<span style="color:#009cb4">*function* **setApprovalForAll** *(address operator, bool approved) external*</span>
 
 Querying the status of approval can be done with:
 

--- a/docs/devguide07.md
+++ b/docs/devguide07.md
@@ -21,7 +21,7 @@ This will emit the following event:
 
 Then positions containing this condition can be redeemed via:
 
-<span style="color:#009cb4">*event* **redeemPositions** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldata indexSets)external*</span>
+<span style="color:#009cb4">*event* **redeemPositions** *(IERC20 collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint[] calldata indexSets) external*</span>
 
 
 This will trigger the following event:


### PR DESCRIPTION
- Add missing spaces to function signatures
- Fix index set (not 100% sure about this one, but I think A|B is 0b011, not 0b110)